### PR TITLE
Update Adafruit_FONA.cpp

### DIFF
--- a/Code/Adafruit_FONA.cpp
+++ b/Code/Adafruit_FONA.cpp
@@ -115,6 +115,8 @@ boolean Adafruit_FONA::begin(Stream &port) {
 
   if (prog_char_strstr(replybuffer, (prog_char *)F("SIM808 R14")) != 0) {
     _type = SIM808_V2;
+  } else if (prog_char_strstr(replybuffer, (prog_char *)F("1418B03SIM808M32_BT_EAT")) != 0) {
+    _type = SIM808_V2; //For Boards with Bluetooth and Extended AT commands for it
   } else if (prog_char_strstr(replybuffer, (prog_char *)F("SIM808 R13")) != 0) {
     _type = SIM808_V1;
   } else if (prog_char_strstr(replybuffer, (prog_char *)F("SIM800 R13")) != 0) {


### PR DESCRIPTION
Some generic eBay boards seem to use a different revision / firmware of the 808 chip that is detected slightly differently - its still an 808 chip, but has the bluetooth and other bits enabled. I will get round to working out some BT functions for it, and as your library is most improved from some of the other, I figured this is as good a start as any.

These boards seem to use the same GPS format as the 808_v2 so for now, make them the same.