### PR TITLE
Remove some warnings and correct an actual bug.

### DIFF
--- a/Code/Adafruit_FONA.cpp
+++ b/Code/Adafruit_FONA.cpp
@@ -2391,7 +2391,7 @@ boolean Adafruit_FONA::FTP_PUT(const char* fileName, const char* filePath, char*
   // Use extended PUT method if there's more than 1024 bytes to send
   if (numBytes >= 1024) {
     // Repeatedly PUT data until all data is sent
-    uint16_t remBytes = numBytes;
+    uint32_t remBytes = numBytes;
     uint16_t offset = 0; // Data offset
     char sendArray[strlen(content)+1];
     strcpy(sendArray, content);

--- a/Code/Adafruit_FONA.cpp
+++ b/Code/Adafruit_FONA.cpp
@@ -1883,7 +1883,7 @@ boolean Adafruit_FONA::postData(const char *request_type, const char *URL, const
 
     char dataBuff[sizeof(bodylen) + 20];
 
-    sprintf(dataBuff, "AT+HTTPDATA=%lu,10000", bodylen);
+    sprintf(dataBuff, "AT+HTTPDATA=%lu,10000", (long unsigned int)bodylen);
     if (! sendCheckReply(dataBuff, "DOWNLOAD", 10000))
       return false;
 

--- a/Code/examples/ESP32_LTE_Demo/ESP32_LTE_Demo.ino
+++ b/Code/examples/ESP32_LTE_Demo/ESP32_LTE_Demo.ino
@@ -790,10 +790,12 @@ void loop() {
         break;
         */
 
-        float latitude, longitude, speed_kph, heading, altitude, second;
+        float latitude, longitude, speed_kph, heading, altitude; 
+        // Comment out the stuff below if you don't care about UTC time
+        /*        float second;
         uint16_t year;
         uint8_t month, day, hour, minute;
-
+        */
         // Use the top line if you want to parse UTC time data as well, the line below it if you don't care
 //        if (fona.getGPS(&latitude, &longitude, &speed_kph, &heading, &altitude, &year, &month, &day, &hour, &minute, &second)) {
         if (fona.getGPS(&latitude, &longitude, &speed_kph, &heading, &altitude)) { // Use this line instead if you don't want UTC time
@@ -957,7 +959,10 @@ void loop() {
         // Create char buffers for the floating point numbers for sprintf
         // Make sure these buffers are long enough for your request URL
         char URL[150];
+        /* Uncomment below if you are going to use the http post method below */
+        /*
         char body[100];
+        */
         char tempBuff[16];
         char battLevelBuff[16];
       


### PR DESCRIPTION
I am in the habit of selecting "Show verbose output during: compilation and upload" and selecting  "Compiler warnings" to All.

When set like this, I got warnings from the base library file "Adafruit_FONA.cpp and from the ESP32_LTE_Demo.ino files.  One warning in the Adafruit_FONA.cpp file was in fact a real bug, the rest were just noisy warnings that really did not need to distract when building.  

I think I made the correct fix to the actual bug and safely turned off the warnings in both files.