### PR TITLE
Timeout fixes

### DIFF
--- a/Code/Adafruit_FONA.cpp
+++ b/Code/Adafruit_FONA.cpp
@@ -937,7 +937,7 @@ boolean Adafruit_FONA::enableNTPTimeSync(boolean onoff, FONAFlashStringPtr ntpse
 }
 
 boolean Adafruit_FONA::getTime(char *buff, uint16_t maxlen) {
-  getReply(F("AT+CCLK?"), (uint16_t) 10000);
+  getReply(F("AT+CCLK?"), 10000U);
   if (strncmp(replybuffer, "+CCLK: ", 7) != 0)
     return false;
 
@@ -1749,7 +1749,7 @@ void Adafruit_FONA::setNetworkSettings(FONAFlashStringPtr apn,
 
 boolean Adafruit_FONA::getGSMLoc(uint16_t *errorcode, char *buff, uint16_t maxlen) {
 
-  getReply(F("AT+CIPGSMLOC=1,1"), (uint16_t)10000);
+  getReply(F("AT+CIPGSMLOC=1,1"), 10000U);
 
   if (! parseReply(F("+CIPGSMLOC: "), errorcode))
     return false;
@@ -2426,7 +2426,7 @@ boolean Adafruit_FONA::FTP_PUT(const char* fileName, const char* filePath, char*
     return false;
 
   uint16_t maxlen;
-  readline(10000);
+  readline(10000U);
   DEBUG_PRINT(F("\t<--- ")); DEBUG_PRINTLN(replybuffer);
   
   // Use regular FTPPUT method if there is less than 1024 bytes of data to send
@@ -3101,7 +3101,7 @@ boolean Adafruit_FONA::HTTP_data(uint32_t size, uint32_t maxTime) {
 }
 
 boolean Adafruit_FONA::HTTP_action(uint8_t method, uint16_t *status,
-                                   uint16_t *datalen, int32_t timeout) {
+                                   uint16_t *datalen, uint32_t timeout) {
   // Send request.
   if (! sendCheckReply(F("AT+HTTPACTION="), method, ok_reply))
     return false;
@@ -3220,7 +3220,7 @@ boolean Adafruit_FONA::HTTP_POST_start(char *url,
   }
 
   // HTTP POST data
-  if (! HTTP_data(postdatalen, 10000))
+  if (! HTTP_data(postdatalen, 10000U))
     return false;
   mySerial->write(postdata, postdatalen);
   if (! expectReply(ok_reply))
@@ -3283,7 +3283,7 @@ boolean Adafruit_FONA::HTTP_setup(char *url) {
 /********* HELPERS *********************************************/
 
 boolean Adafruit_FONA::expectReply(FONAFlashStringPtr reply,
-                                   uint16_t timeout) {
+                                   uint32_t timeout) {
   readline(timeout);
 
   DEBUG_PRINT(F("\t<--- ")); DEBUG_PRINTLN(replybuffer);
@@ -3340,7 +3340,7 @@ uint16_t Adafruit_FONA::readRaw(uint16_t b) {
   return idx;
 }
 
-uint8_t Adafruit_FONA::readline(uint16_t timeout, boolean multiline) {
+uint8_t Adafruit_FONA::readline(uint32_t timeout, boolean multiline) {
   uint16_t replyidx = 0;
 
   while (timeout--) {
@@ -3376,7 +3376,7 @@ uint8_t Adafruit_FONA::readline(uint16_t timeout, boolean multiline) {
   return replyidx;
 }
 
-uint8_t Adafruit_FONA::getReply(const char *send, uint16_t timeout) {
+uint8_t Adafruit_FONA::getReply(const char *send, uint32_t timeout) {
   flushInput();
 
 
@@ -3392,7 +3392,7 @@ uint8_t Adafruit_FONA::getReply(const char *send, uint16_t timeout) {
   return l;
 }
 
-uint8_t Adafruit_FONA::getReply(FONAFlashStringPtr send, uint16_t timeout) {
+uint8_t Adafruit_FONA::getReply(FONAFlashStringPtr send, uint32_t timeout) {
   flushInput();
 
 
@@ -3409,7 +3409,7 @@ uint8_t Adafruit_FONA::getReply(FONAFlashStringPtr send, uint16_t timeout) {
 }
 
 // Send prefix, suffix, and newline. Return response (and also set replybuffer with response).
-uint8_t Adafruit_FONA::getReply(FONAFlashStringPtr prefix, char *suffix, uint16_t timeout) {
+uint8_t Adafruit_FONA::getReply(FONAFlashStringPtr prefix, char *suffix, uint32_t timeout) {
   flushInput();
 
 
@@ -3427,7 +3427,7 @@ uint8_t Adafruit_FONA::getReply(FONAFlashStringPtr prefix, char *suffix, uint16_
 }
 
 // Send prefix, suffix, and newline. Return response (and also set replybuffer with response).
-uint8_t Adafruit_FONA::getReply(FONAFlashStringPtr prefix, int32_t suffix, uint16_t timeout) {
+uint8_t Adafruit_FONA::getReply(FONAFlashStringPtr prefix, int32_t suffix, uint32_t timeout) {
   flushInput();
 
 
@@ -3445,7 +3445,7 @@ uint8_t Adafruit_FONA::getReply(FONAFlashStringPtr prefix, int32_t suffix, uint1
 }
 
 // Send prefix, suffix, suffix2, and newline. Return response (and also set replybuffer with response).
-uint8_t Adafruit_FONA::getReply(FONAFlashStringPtr prefix, int32_t suffix1, int32_t suffix2, uint16_t timeout) {
+uint8_t Adafruit_FONA::getReply(FONAFlashStringPtr prefix, int32_t suffix1, int32_t suffix2, uint32_t timeout) {
   flushInput();
 
 
@@ -3466,7 +3466,7 @@ uint8_t Adafruit_FONA::getReply(FONAFlashStringPtr prefix, int32_t suffix1, int3
 }
 
 // Send prefix, ", suffix, ", and newline. Return response (and also set replybuffer with response).
-uint8_t Adafruit_FONA::getReplyQuoted(FONAFlashStringPtr prefix, FONAFlashStringPtr suffix, uint16_t timeout) {
+uint8_t Adafruit_FONA::getReplyQuoted(FONAFlashStringPtr prefix, FONAFlashStringPtr suffix, uint32_t timeout) {
   flushInput();
 
 
@@ -3486,7 +3486,7 @@ uint8_t Adafruit_FONA::getReplyQuoted(FONAFlashStringPtr prefix, FONAFlashString
   return l;
 }
 
-boolean Adafruit_FONA::sendCheckReply(const char *send, const char *reply, uint16_t timeout) {
+boolean Adafruit_FONA::sendCheckReply(const char *send, const char *reply, uint32_t timeout) {
   if (! getReply(send, timeout) )
     return false;
 /*
@@ -3502,14 +3502,14 @@ boolean Adafruit_FONA::sendCheckReply(const char *send, const char *reply, uint1
   return (strcmp(replybuffer, reply) == 0);
 }
 
-boolean Adafruit_FONA::sendCheckReply(FONAFlashStringPtr send, FONAFlashStringPtr reply, uint16_t timeout) {
+boolean Adafruit_FONA::sendCheckReply(FONAFlashStringPtr send, FONAFlashStringPtr reply, uint32_t timeout) {
   if (! getReply(send, timeout) )
     return false;
 
   return (prog_char_strcmp(replybuffer, (prog_char*)reply) == 0);
 }
 
-boolean Adafruit_FONA::sendCheckReply(const char* send, FONAFlashStringPtr reply, uint16_t timeout) {
+boolean Adafruit_FONA::sendCheckReply(const char* send, FONAFlashStringPtr reply, uint32_t timeout) {
   if (! getReply(send, timeout) )
     return false;
   return (prog_char_strcmp(replybuffer, (prog_char*)reply) == 0);
@@ -3517,25 +3517,25 @@ boolean Adafruit_FONA::sendCheckReply(const char* send, FONAFlashStringPtr reply
 
 
 // Send prefix, suffix, and newline.  Verify FONA response matches reply parameter.
-boolean Adafruit_FONA::sendCheckReply(FONAFlashStringPtr prefix, char *suffix, FONAFlashStringPtr reply, uint16_t timeout) {
+boolean Adafruit_FONA::sendCheckReply(FONAFlashStringPtr prefix, char *suffix, FONAFlashStringPtr reply, uint32_t timeout) {
   getReply(prefix, suffix, timeout);
   return (prog_char_strcmp(replybuffer, (prog_char*)reply) == 0);
 }
 
 // Send prefix, suffix, and newline.  Verify FONA response matches reply parameter.
-boolean Adafruit_FONA::sendCheckReply(FONAFlashStringPtr prefix, int32_t suffix, FONAFlashStringPtr reply, uint16_t timeout) {
+boolean Adafruit_FONA::sendCheckReply(FONAFlashStringPtr prefix, int32_t suffix, FONAFlashStringPtr reply, uint32_t timeout) {
   getReply(prefix, suffix, timeout);
   return (prog_char_strcmp(replybuffer, (prog_char*)reply) == 0);
 }
 
 // Send prefix, suffix, suffix2, and newline.  Verify FONA response matches reply parameter.
-boolean Adafruit_FONA::sendCheckReply(FONAFlashStringPtr prefix, int32_t suffix1, int32_t suffix2, FONAFlashStringPtr reply, uint16_t timeout) {
+boolean Adafruit_FONA::sendCheckReply(FONAFlashStringPtr prefix, int32_t suffix1, int32_t suffix2, FONAFlashStringPtr reply, uint32_t timeout) {
   getReply(prefix, suffix1, suffix2, timeout);
   return (prog_char_strcmp(replybuffer, (prog_char*)reply) == 0);
 }
 
 // Send prefix, ", suffix, ", and newline.  Verify FONA response matches reply parameter.
-boolean Adafruit_FONA::sendCheckReplyQuoted(FONAFlashStringPtr prefix, FONAFlashStringPtr suffix, FONAFlashStringPtr reply, uint16_t timeout) {
+boolean Adafruit_FONA::sendCheckReplyQuoted(FONAFlashStringPtr prefix, FONAFlashStringPtr suffix, FONAFlashStringPtr reply, uint32_t timeout) {
   getReplyQuoted(prefix, suffix, timeout);
   return (prog_char_strcmp(replybuffer, (prog_char*)reply) == 0);
 }

--- a/Code/Adafruit_FONA.cpp
+++ b/Code/Adafruit_FONA.cpp
@@ -1623,12 +1623,12 @@ boolean Adafruit_FONA::enableGPRS(boolean onoff) {
       }
 
       // open bearer
-      if (! sendCheckReply(F("AT+SAPBR=1,1"), ok_reply, 30000))
+      if (! sendCheckReply(F("AT+SAPBR=1,1"), ok_reply, 85000))
         return false;
 
       // if (_type < SIM7000) { // UNCOMMENT FOR LTE ONLY!
         // bring up wireless connection
-        if (! sendCheckReply(F("AT+CIICR"), ok_reply, 10000))
+        if (! sendCheckReply(F("AT+CIICR"), ok_reply, 85000))
           return false;
       // } // UNCOMMENT FOR LTE ONLY!
 
@@ -1641,7 +1641,7 @@ boolean Adafruit_FONA::enableGPRS(boolean onoff) {
         return false;
 
       // close bearer
-      if (! sendCheckReply(F("AT+SAPBR=0,1"), ok_reply, 10000))
+      if (! sendCheckReply(F("AT+SAPBR=0,1"), ok_reply, 65000))
         return false;
 
       // if (_type < SIM7000) { // UNCOMMENT FOR LTE ONLY!

--- a/Code/Adafruit_FONA.h
+++ b/Code/Adafruit_FONA.h
@@ -231,7 +231,7 @@ class Adafruit_FONA : public FONAStreamType {
   boolean HTTP_para(FONAFlashStringPtr parameter, FONAFlashStringPtr value);
   boolean HTTP_para(FONAFlashStringPtr parameter, int32_t value);
   boolean HTTP_data(uint32_t size, uint32_t maxTime=10000);
-  boolean HTTP_action(uint8_t method, uint16_t *status, uint16_t *datalen, int32_t timeout = 10000);
+  boolean HTTP_action(uint8_t method, uint16_t *status, uint16_t *datalen, uint32_t timeout = 10000);
   boolean HTTP_readall(uint16_t *datalen);
   boolean HTTP_ssl(boolean onoff);
 
@@ -257,10 +257,10 @@ class Adafruit_FONA : public FONAStreamType {
   boolean incomingCallNumber(char* phonenum);
 
   // Helper functions to verify responses.
-  boolean expectReply(FONAFlashStringPtr reply, uint16_t timeout = 10000);
-  boolean sendCheckReply(const char *send, const char *reply, uint16_t timeout = FONA_DEFAULT_TIMEOUT_MS);
-  boolean sendCheckReply(FONAFlashStringPtr send, FONAFlashStringPtr reply, uint16_t timeout = FONA_DEFAULT_TIMEOUT_MS);
-  boolean sendCheckReply(const char* send, FONAFlashStringPtr reply, uint16_t timeout = FONA_DEFAULT_TIMEOUT_MS);
+  boolean expectReply(FONAFlashStringPtr reply, uint32_t timeout = 10000);
+  boolean sendCheckReply(const char *send, const char *reply, uint32_t timeout = FONA_DEFAULT_TIMEOUT_MS);
+  boolean sendCheckReply(FONAFlashStringPtr send, FONAFlashStringPtr reply, uint32_t timeout = FONA_DEFAULT_TIMEOUT_MS);
+  boolean sendCheckReply(const char* send, FONAFlashStringPtr reply, uint32_t timeout = FONA_DEFAULT_TIMEOUT_MS);
 
 
  protected:
@@ -280,18 +280,18 @@ class Adafruit_FONA : public FONAStreamType {
 
   void flushInput();
   uint16_t readRaw(uint16_t b);
-  uint8_t readline(uint16_t timeout = FONA_DEFAULT_TIMEOUT_MS, boolean multiline = false);
-  uint8_t getReply(const char *send, uint16_t timeout = FONA_DEFAULT_TIMEOUT_MS);
-  uint8_t getReply(FONAFlashStringPtr send, uint16_t timeout = FONA_DEFAULT_TIMEOUT_MS);
-  uint8_t getReply(FONAFlashStringPtr prefix, char *suffix, uint16_t timeout = FONA_DEFAULT_TIMEOUT_MS);
-  uint8_t getReply(FONAFlashStringPtr prefix, int32_t suffix, uint16_t timeout = FONA_DEFAULT_TIMEOUT_MS);
-  uint8_t getReply(FONAFlashStringPtr prefix, int32_t suffix1, int32_t suffix2, uint16_t timeout); // Don't set default value or else function call is ambiguous.
-  uint8_t getReplyQuoted(FONAFlashStringPtr prefix, FONAFlashStringPtr suffix, uint16_t timeout = FONA_DEFAULT_TIMEOUT_MS);
+  uint8_t readline(uint32_t timeout = FONA_DEFAULT_TIMEOUT_MS, boolean multiline = false);
+  uint8_t getReply(const char *send, uint32_t timeout = FONA_DEFAULT_TIMEOUT_MS);
+  uint8_t getReply(FONAFlashStringPtr send, uint32_t timeout = FONA_DEFAULT_TIMEOUT_MS);
+  uint8_t getReply(FONAFlashStringPtr prefix, char *suffix, uint32_t timeout = FONA_DEFAULT_TIMEOUT_MS);
+  uint8_t getReply(FONAFlashStringPtr prefix, int32_t suffix, uint32_t timeout = FONA_DEFAULT_TIMEOUT_MS);
+  uint8_t getReply(FONAFlashStringPtr prefix, int32_t suffix1, int32_t suffix2, uint32_t timeout); // Don't set default value or else function call is ambiguous.
+  uint8_t getReplyQuoted(FONAFlashStringPtr prefix, FONAFlashStringPtr suffix, uint32_t timeout = FONA_DEFAULT_TIMEOUT_MS);
 
-  boolean sendCheckReply(FONAFlashStringPtr prefix, char *suffix, FONAFlashStringPtr reply, uint16_t timeout = FONA_DEFAULT_TIMEOUT_MS);
-  boolean sendCheckReply(FONAFlashStringPtr prefix, int32_t suffix, FONAFlashStringPtr reply, uint16_t timeout = FONA_DEFAULT_TIMEOUT_MS);
-  boolean sendCheckReply(FONAFlashStringPtr prefix, int32_t suffix, int32_t suffix2, FONAFlashStringPtr reply, uint16_t timeout = FONA_DEFAULT_TIMEOUT_MS);
-  boolean sendCheckReplyQuoted(FONAFlashStringPtr prefix, FONAFlashStringPtr suffix, FONAFlashStringPtr reply, uint16_t timeout = FONA_DEFAULT_TIMEOUT_MS);
+  boolean sendCheckReply(FONAFlashStringPtr prefix, char *suffix, FONAFlashStringPtr reply, uint32_t timeout = FONA_DEFAULT_TIMEOUT_MS);
+  boolean sendCheckReply(FONAFlashStringPtr prefix, int32_t suffix, FONAFlashStringPtr reply, uint32_t timeout = FONA_DEFAULT_TIMEOUT_MS);
+  boolean sendCheckReply(FONAFlashStringPtr prefix, int32_t suffix, int32_t suffix2, FONAFlashStringPtr reply, uint32_t timeout = FONA_DEFAULT_TIMEOUT_MS);
+  boolean sendCheckReplyQuoted(FONAFlashStringPtr prefix, FONAFlashStringPtr suffix, FONAFlashStringPtr reply, uint32_t timeout = FONA_DEFAULT_TIMEOUT_MS);
 
   void mqtt_connect_message(const char *protocol, byte *mqtt_message, const char *client_id, const char *username, const char *password);
   void mqtt_publish_message(byte *mqtt_message, const char *topic, const char *message);


### PR DESCRIPTION
Some commands on the SIM7000E have a timeout of 65s or more according to spec. 
In order to accommodate for these I changed all timeout related variables to be uint32_t instead of uint16_t. (not all commands are necessarily needed, I mostly did it for consistency sake)